### PR TITLE
feat: Add Docker Push to CI Pipeline 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - master
+
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build all services with docker-compose
+        run: docker compose build
+
+      - name: Start services
+        run: docker compose up -d
+
+      - name: Wait for API to be healthy
+        run: |
+          for i in {1..30}; do
+            status=$(docker inspect --format='{{json .State.Health.Status}}' $(docker compose ps -q api) 2>/dev/null || echo '"starting"')
+            if [ "$status" = "\"healthy\"" ]; then
+              echo "API is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "API failed to become healthy"
+          docker compose logs
+          exit 1
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v
+
+  publish:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push with docker-compose
+        run: docker compose build && docker compose push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/add-ci-pipeline'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches: 
+      - master
 
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,6 @@ jobs:
       - name: Start services
         run: docker compose up -d
 
-      - name: Wait for API to be healthy
-        run: |
-          for i in {1..30}; do
-            status=$(docker inspect --format='{{json .State.Health.Status}}' $(docker compose ps -q api) 2>/dev/null || echo '"starting"')
-            if [ "$status" = "\"healthy\"" ]; then
-              echo "API is healthy"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "API failed to become healthy"
-          docker compose logs
-          exit 1
-
       - name: Tear down
         if: always()
         run: docker compose down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set image variables
+        run: |
+            echo "OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${GITHUB_SHA}" >> $GITHUB_ENV
+
       - name: Build & Push with docker-compose
         run: docker compose build && docker compose push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,4 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose down -v
-
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Login to registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push with docker-compose
-        run: docker compose build && docker compose push
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -30,7 +30,7 @@ jobs:
         run: docker compose down -v
 
   publish:
-    needs: build-and-test
+    needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,21 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose down -v
-        
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/add-ci-pipeline'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push with docker-compose
+        run: docker compose build && docker compose push

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./ui-shell
       dockerfile: Dockerfile  
-    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
+    image: ghcr.io/${OWNER:-local}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5173:5173"   
     depends_on:
@@ -19,7 +19,7 @@ services:
     build:
       context: ./ui-services/matching-ui-service
       dockerfile: Dockerfile
-    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
+    image: ghcr.io/${OWNER:-local}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5174:5174"
     container_name: peerprep-matching-ui
@@ -28,7 +28,7 @@ services:
     build:
       context: ./ui-services/question-ui-service
       dockerfile: Dockerfile
-    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
+    image: ghcr.io/${OWNER:-local}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5175:5175"
     container_name: peerprep-question-ui
@@ -37,7 +37,7 @@ services:
     build:
       context: ./ui-services/collab-ui-service
       dockerfile: Dockerfile
-    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
+    image: ghcr.io/${OWNER:-local}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5176:5176"
     container_name: peerprep-collab-ui
@@ -46,7 +46,7 @@ services:
     build:
       context: ./ui-services/user-ui-service
       dockerfile: Dockerfile
-    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
+    image: ghcr.io/${OWNER:-local}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5177:5177"
     container_name: peerprep-user-ui
@@ -54,7 +54,7 @@ services:
     build:
       context: ./ui-services/history-ui-service
       dockerfile: Dockerfile
-    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
+    image: ghcr.io/${OWNER:-local}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5178:5178"
     container_name: peerprep-history-ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: ./ui-shell
       dockerfile: Dockerfile  
+    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5173:5173"   
     depends_on:
@@ -18,6 +19,7 @@ services:
     build:
       context: ./ui-services/matching-ui-service
       dockerfile: Dockerfile
+    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5174:5174"
     container_name: peerprep-matching-ui
@@ -26,6 +28,7 @@ services:
     build:
       context: ./ui-services/question-ui-service
       dockerfile: Dockerfile
+    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5175:5175"
     container_name: peerprep-question-ui
@@ -34,6 +37,7 @@ services:
     build:
       context: ./ui-services/collab-ui-service
       dockerfile: Dockerfile
+    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5176:5176"
     container_name: peerprep-collab-ui
@@ -42,6 +46,7 @@ services:
     build:
       context: ./ui-services/user-ui-service
       dockerfile: Dockerfile
+    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5177:5177"
     container_name: peerprep-user-ui
@@ -49,6 +54,7 @@ services:
     build:
       context: ./ui-services/history-ui-service
       dockerfile: Dockerfile
+    image: ghcr.io/${OWNER}/matching-ui:${IMAGE_TAG:-local}
     ports:
       - "5178:5178"
     container_name: peerprep-history-ui


### PR DESCRIPTION
To publish to GitHub, we will need to convert the docker.io/... version to the ghcr.io/<owner>/<image>:<tag> version accordingly. However, to ensure that it is pushed as docker.io/... locally so we can run it with Docker Desktop, the solution requires us to run docker compose for the services separately to override the compose image for each CI manually.

Moreover, there is room work on caching the different built images to speed up the build and publish process in GitHub Actions (or to allow them to run in parallel).

❗ **Update: Have merged both building and publishing the docker image in #10**