### PR TITLE
fix: Reconfigure docker publish destination

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -43,18 +43,14 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ steps.lc.outputs.value }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Extract Docker metadata (tags/labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ steps.lc.outputs.value }}/peerprep-${{ matrix.service.name }}
+            ghcr.io/CS3219-AY2526Sem1/cs3219-ay2526s1-project-g09/peerprep-${{ matrix.service.name }}
           tags: |
             type=raw,value=${{ github.sha }}
             type=ref,event=branch

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -69,7 +69,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build & Push
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.service.context }}


### PR DESCRIPTION
## Description

Previously in #11 there are issues where the packages are published to the classroom `CS3219-AY2526Sem1`, which is not desired as all members of the repo/classroom would able to download the packages. In this PR, we want to make the packages publish to only the group's repo - [`cs3219-ay2526s1-project-g09`](https://github.com/CS3219-AY2526Sem1/cs3219-ay2526s1-project-g09). 